### PR TITLE
Various little fixes

### DIFF
--- a/foreach.inc
+++ b/foreach.inc
@@ -547,9 +547,7 @@ Notes:
 #define foreachex(%1,%2) foreach(%2:%1)
 	//for(%2=_Y_ITER_ARRAY_SIZE(%1);(%2=_Y_ITER_ARRAY:%1@YSII_Ag[%2])!=_Y_ITER_ARRAY_SIZE(%1);)
 
-
-/*
---------------------------------------------------------------------------------
+/*----------------------------------------------------------------------------*\
 Function:
 	Iter_ScriptInit
 Params:
@@ -558,23 +556,11 @@ Return:
 	-
 Notes:
 	-
---------------------------------------------------------------------------------
-*/
+\*----------------------------------------------------------------------------*/
 
 stock Iter_ScriptInit()
 {
-	#if defined GetPlayerPoolSize && !defined _INC_open_mp && !defined _inc_fixes
-		new
-			LAST_PLAYER_ID = GetPlayerPoolSize() + 1,
-			LAST_VEHICLE_ID = GetVehiclePoolSize() + 1,
-			LAST_ACTOR_ID = GetActorPoolSize() + 1;
-	#else
-		new
-			LAST_PLAYER_ID = MAX_PLAYERS,
-			LAST_VEHICLE_ID = MAX_VEHICLES,
-			LAST_ACTOR_ID = MAX_ACTORS;
-	#endif
-
+	// Clear everything.
 	Iter_Clear(Player);
 	#if defined _FOREACH_BOT && !defined FOREACH_NO_BOTS
 		Iter_Clear(Bot);
@@ -583,8 +569,7 @@ stock Iter_ScriptInit()
 
 	#if FOREACH_I_Vehicle
 		Iter_Clear(Vehicle);
-
-		for(new vehicleid = 1; vehicleid != LAST_VEHICLE_ID; ++vehicleid) {
+		for(new vehicleid = 1; vehicleid != MAX_VEHICLES; ++vehicleid) {
 			if(!GetVehicleModel(vehicleid)) {
 				continue;
 			}
@@ -593,7 +578,7 @@ stock Iter_ScriptInit()
 	#endif
 
 	Iter_Clear(Actor);
-	for(new actorid = 0; actorid != LAST_ACTOR_ID; ++actorid) {
+	for(new actorid = 0; actorid != MAX_ACTORS; ++actorid) {
 		if(!IsValidActor(actorid)) {
 			continue;
 		}
@@ -606,8 +591,6 @@ stock Iter_ScriptInit()
 	if(funcidx(YSI_gsOnPlayerConnect) != -1) {
 		YSI_g_sCallbacks |= 2;
 	}
-
-	#pragma unused LAST_PLAYER_ID, LAST_VEHICLE_ID, LAST_ACTOR_ID
 }
 
 /*----------------------------------------------------------------------------*\
@@ -626,6 +609,7 @@ Notes:
 	public OnFilterScriptInit()
 	{
 		Iter_ScriptInit();
+		// Do the forward iterator list.
 		#if defined _FOREACH_BOT && !defined FOREACH_NO_BOTS
 			Bot@YSII_Cg = _Y_ITER_C3:0;
 			Character@YSII_Cg = _Y_ITER_C3:0;
@@ -640,15 +624,13 @@ Notes:
 			if(IsPlayerConnected(i)) {
 				#if defined _FOREACH_BOT
 					// Had to do "if ! else" due to compile options.
-					if(!IsPlayerNPC(i))
-					{
+					if(!IsPlayerNPC(i)) {
 						Player@YSII_Ag[lastPlayer] = i;
 						++Player@YSII_Cg;
 						lastPlayer = i;
 					}
 					#if !defined FOREACH_NO_BOTS
-						else
-						{
+						else {
 							Bot@YSII_Ag[lastBot] = i;
 							++Bot@YSII_Cg;
 							lastBot = i;
@@ -709,7 +691,6 @@ Notes:
 #if !defined BOTSYNC_IS_BOT
 	public OnGameModeInit()
 	{
-		// Clear everything.
 		Iter_ScriptInit();
 		if(!Player@YSII_Cg) {
 			#if defined _FOREACH_BOT && !defined FOREACH_NO_BOTS
@@ -737,15 +718,13 @@ Notes:
 			if(IsPlayerConnected(i)) {
 				#if defined _FOREACH_BOT
 					// Had to do "if ! else" due to compile options.
-					if(!IsPlayerNPC(i))
-					{
+					if(!IsPlayerNPC(i)) {
 						Player@YSII_Ag[lastPlayer] = i;
 						++Player@YSII_Cg;
 						lastPlayer = i;
 					}
 					#if !defined FOREACH_NO_BOTS
-						else
-						{
+						else {
 							Bot@YSII_Ag[lastBot] = i;
 							++Bot@YSII_Cg;
 							lastBot = i;
@@ -824,8 +803,7 @@ Notes:
 		#else
 			Iter_Add(Player, playerid);
 		#endif
-		if(YSI_g_sCallbacks & 2)
-		{
+		if(YSI_g_sCallbacks & 2) {
 			CallLocalFunction(YSI_gsOnPlayerConnect, YSI_gsSpecifier@i, playerid);
 		}
 		return 1;
@@ -907,24 +885,16 @@ Notes:
 	}
 #endif
 
-/*
-	VEHICLES
-*/
+/* VEHICLES */
 
 #if FOREACH_I_Vehicle
 
-	/*
-		Iter_CreateVehicle
-	*/
+	/* Iter_CreateVehicle */
 
-#if defined _INC_open_mp
-	stock Iter_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, bool:addsiren = false)
-#else
 	stock Iter_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, addsiren = 0)
-#endif
 	{
 		new
-			ret = CreateVehicle(modelid, x, y, z, angle, color1, color2, respawn_delay, addsiren);
+			ret = CreateVehicle(modelid, x, y, z, angle, color1, color2, respawn_delay, !!addsiren);
 
 		if(ret != INVALID_VEHICLE_ID && ret != 0) {
 			Iter_Add(Vehicle, ret);
@@ -936,12 +906,9 @@ Notes:
 	#else
 		#define _ALS_CreateVehicle
 	#endif
-
 	#define CreateVehicle Iter_CreateVehicle
 
-	/*
-		Iter_AddStaticVehicle
-	*/
+	/* Iter_AddStaticVehicle */
 
 	stock Iter_AddStaticVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2)
 	{
@@ -958,21 +925,14 @@ Notes:
 	#else
 		#define _ALS_AddStaticVehicle
 	#endif
-
 	#define AddStaticVehicle Iter_AddStaticVehicle
 
-	/*
-		Iter_AddStaticVehicleEx
-	*/
+	/* Iter_AddStaticVehicleEx */
 
-#if defined _INC_open_mp
-	stock Iter_AddStaticVehicleEx(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, bool:addsiren = false)
-#else
 	stock Iter_AddStaticVehicleEx(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, addsiren = 0)
-#endif
 	{
 		new
-			ret = AddStaticVehicleEx(modelid, x, y, z, angle, color1, color2, respawn_delay, addsiren);
+			ret = AddStaticVehicleEx(modelid, x, y, z, angle, color1, color2, respawn_delay, !!addsiren);
 
 		if(ret != INVALID_VEHICLE_ID) {
 			Iter_Add(Vehicle, ret);
@@ -984,12 +944,9 @@ Notes:
 	#else
 		#define _ALS_AddStaticVehicleEx
 	#endif
-
 	#define AddStaticVehicleEx Iter_AddStaticVehicleEx
 
-	/*
-		DestroyVehicleSafe
-	*/
+	/* DestroyVehicleSafe */
 
 	stock DestroyVehicleSafe(&vehicleid)
 	{
@@ -998,9 +955,7 @@ Notes:
 		return success;
 	}
 
-	/*
-		Iter_DestroyVehicle
-	*/
+	/* Iter_DestroyVehicle */
 
 	stock Iter_DestroyVehicle(vehicleid)
 	{
@@ -1012,18 +967,13 @@ Notes:
 	#else
 		#define _ALS_DestroyVehicle
 	#endif
-
 	#define DestroyVehicle Iter_DestroyVehicle
 
 #endif
 
-/*
-	ACTORS
-*/
+/* ACTORS */
 
-/*
-	Iter_CreateActor
-*/
+/* Iter_CreateActor */
 
 stock Iter_CreateActor(modelid, Float:x, Float:y, Float:z, Float:zAngle)
 {
@@ -1039,12 +989,9 @@ stock Iter_CreateActor(modelid, Float:x, Float:y, Float:z, Float:zAngle)
 #else
 	#define _ALS_CreateActor
 #endif
-
 #define CreateActor Iter_CreateActor
 
-/*
-	DestroyActorSafe
-*/
+/* DestroyActorSafe */
 
 stock DestroyActorSafe(&actorid)
 {
@@ -1053,9 +1000,7 @@ stock DestroyActorSafe(&actorid)
 	return success;
 }
 
-/*
-	Iter_DestroyActor
-*/
+/* Iter_DestroyActor */
 
 stock Iter_DestroyActor(actorid)
 {
@@ -1067,7 +1012,6 @@ stock Iter_DestroyActor(actorid)
 #else
 	#define _ALS_DestroyActor
 #endif
-
 #define DestroyActor Iter_DestroyActor
 
 /*----------------------------------------------------------------------------*\
@@ -1091,7 +1035,7 @@ stock Iter_RandomInternal(count, const array[], size)
 	new
 		rnd = random(count),
 		cur = array[size];
-	while (cur != size) {
+	while(cur != size) {
 		if(rnd-- == 0) {
 			return cur;
 		}
@@ -1148,7 +1092,7 @@ stock Iter_AddInternal(&count, array[], value, size)
 		new
 			last = size,
 			next = array[last];
-		while (next < value) {
+		while(next < value) {
 			last = next;
 			next = array[last];
 		}
@@ -1198,13 +1142,11 @@ Notes:
 
 /*stock Iter_SafeRemoveInternal(&count, array[], value, &last, size)
 {
-	if(0 <= value < size && array[value] <= size)
-	{
+	if(0 <= value < size && array[value] <= size) {
 		last = size;
 		new
 			next = array[last];
-		while (next != value)
-		{
+		while(next != value) {
 			last = next;
 			next = array[last];
 		}
@@ -1222,7 +1164,7 @@ stock Iter_SafeRemoveInternal(&count, array[], value, &last, size)
 		last = size;
 		new
 			next = array[last];
-		while (next < size) {
+		while(next < size) {
 			if(next == value) {
 				array[last] = array[value];
 				array[value] = size + 1;
@@ -1317,10 +1259,10 @@ stock Iter_PrevInternal(array[], size, slot)
 {
 	if(0 <= slot <= size && array[slot] <= size) {
 		for(new last = slot; last--; ) {
- 			if(array[last] == slot) {
- 				return last;
- 			}
- 		}
+			if(array[last] == slot) {
+				return last;
+			}
+		}
 	}
 	return size;
 }
@@ -1408,26 +1350,26 @@ Notes:
 
 /*----------------------------------------------------------------------------*\
 Function:
-    Iter_InternalArray
+	Iter_InternalArray
 Params:
-    iter - Name of the iterator to get the true name of.
+	iter - Name of the iterator to get the true name of.
 Return:
-    -
+	-
 Notes:
-    Accesses the internal array of an iterator.
+	Accesses the internal array of an iterator.
 \*----------------------------------------------------------------------------*/
 
 #define Iter_InternalArray(%1) (_Y_ITER_ARRAY:%1@YSII_Ag)
 
 /*----------------------------------------------------------------------------*\
 Function:
-    Iter_InternalSize
+	Iter_InternalSize
 Params:
-    iter - Name of the iterator to get the true size of.
+	iter - Name of the iterator to get the true size of.
 Return:
-    -
+	-
 Notes:
-    Accesses the internal size of an iterator.
+	Accesses the internal size of an iterator.
 \*----------------------------------------------------------------------------*/
 
 #define _Y_ITER_INT_SIZE:%0(%2[%1]@YSII_Ag)) %0(%2@YSII_Ag[]))

--- a/foreach.inc
+++ b/foreach.inc
@@ -218,7 +218,6 @@ Iterators:
 
 //#define _Y_ITER_C3:%0[%1]@YSII_Cg,%2[%3]@YSII_Ag[%4]={%5} _Y_ITER_C3:%0@YSII_Cg[%4-1],%0@YSII_Ag[%1][%4]
 
-
 #if !defined BOTSYNC_IS_BOT
 	static stock
 		YSI_g_sCallbacks = 0;
@@ -228,8 +227,10 @@ Iterators:
 	#if !defined FOREACH_I_Vehicle
 		#define FOREACH_I_Vehicle 1
 	#endif
-#elseif !defined FOREACH_I_Vehicle
-	#define FOREACH_I_Vehicle 0
+#else
+	#if !defined FOREACH_I_Vehicle
+		#define FOREACH_I_Vehicle 0
+	#endif
 #endif
 
 /*----------------------------------------------------------------------------*\
@@ -692,14 +693,6 @@ Notes:
 	public OnGameModeInit()
 	{
 		Iter_ScriptInit();
-		if(!Player@YSII_Cg) {
-			#if defined _FOREACH_BOT && !defined FOREACH_NO_BOTS
-				CallLocalFunction(YSI_gsOnGameModeInit, YSI_gsSpecifier@, Bot@YSII_Cg, Character@YSII_Cg, Player@YSII_Cg);
-			#else
-				CallLocalFunction(YSI_gsOnGameModeInit, YSI_gsSpecifier@, Player@YSII_Cg);
-			#endif
-			return 1;
-		}
 		// Do the forward iterator list.
 		#if defined _FOREACH_BOT && !defined FOREACH_NO_BOTS
 			Bot@YSII_Cg = _Y_ITER_C3:0;

--- a/foreach.inc
+++ b/foreach.inc
@@ -222,14 +222,14 @@ Iterators:
 #if !defined BOTSYNC_IS_BOT
 	static stock
 		YSI_g_sCallbacks = 0;
-#endif
 
-#if !defined BOTSYNC_IS_BOT
 	forward Iter_OPDCInternal(playerid);
-#endif
 
-#if !defined FOREACH_I_Vehicle
-	#define FOREACH_I_Vehicle 1
+	#if !defined FOREACH_I_Vehicle
+		#define FOREACH_I_Vehicle 1
+	#endif
+#elseif !defined FOREACH_I_Vehicle
+	#define FOREACH_I_Vehicle 0
 #endif
 
 /*----------------------------------------------------------------------------*\
@@ -888,7 +888,6 @@ Notes:
 /* VEHICLES */
 
 #if FOREACH_I_Vehicle
-
 	/* Iter_CreateVehicle */
 
 	stock Iter_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, addsiren = 0)
@@ -901,6 +900,7 @@ Notes:
 		}
 		return ret;
 	}
+
 	#if defined _ALS_CreateVehicle
 		#undef CreateVehicle
 	#else
@@ -920,6 +920,7 @@ Notes:
 		}
 		return ret;
 	}
+
 	#if defined _ALS_AddStaticVehicle
 		#undef AddStaticVehicle
 	#else
@@ -939,6 +940,7 @@ Notes:
 		}
 		return ret;
 	}
+
 	#if defined _ALS_AddStaticVehicleEx
 		#undef AddStaticVehicleEx
 	#else
@@ -962,57 +964,61 @@ Notes:
 		Iter_Remove(Vehicle, vehicleid);
 		return DestroyVehicle(vehicleid);
 	}
+
 	#if defined _ALS_DestroyVehicle
 		#undef DestroyVehicle
 	#else
 		#define _ALS_DestroyVehicle
 	#endif
 	#define DestroyVehicle Iter_DestroyVehicle
-
 #endif
 
 /* ACTORS */
 
-/* Iter_CreateActor */
+#if !defined BOTSYNC_IS_BOT
+	/* Iter_CreateActor */
 
-stock Iter_CreateActor(modelid, Float:x, Float:y, Float:z, Float:zAngle)
-{
-	new
-		ret = CreateActor(modelid, x, y, z, zAngle);
-	if(ret != INVALID_ACTOR_ID) {
-		Iter_Add(Actor, ret);
+	stock Iter_CreateActor(modelid, Float:x, Float:y, Float:z, Float:zAngle)
+	{
+		new
+			ret = CreateActor(modelid, x, y, z, zAngle);
+		if(ret != INVALID_ACTOR_ID) {
+			Iter_Add(Actor, ret);
+		}
+		return ret;
 	}
-	return ret;
-}
-#if defined _ALS_CreateActor
-	#undef CreateActor
-#else
-	#define _ALS_CreateActor
+
+	#if defined _ALS_CreateActor
+		#undef CreateActor
+	#else
+		#define _ALS_CreateActor
+	#endif
+	#define CreateActor Iter_CreateActor
+
+	/* DestroyActorSafe */
+
+	stock DestroyActorSafe(&actorid)
+	{
+		new success = DestroyActor(actorid);
+		Iter_SafeRemove(Actor, actorid, actorid);
+		return success;
+	}
+
+	/* Iter_DestroyActor */
+
+	stock Iter_DestroyActor(actorid)
+	{
+		Iter_Remove(Actor, actorid);
+		return DestroyActor(actorid);
+	}
+
+	#if defined _ALS_DestroyActor
+		#undef DestroyActor
+	#else
+		#define _ALS_DestroyActor
+	#endif
+	#define DestroyActor Iter_DestroyActor
 #endif
-#define CreateActor Iter_CreateActor
-
-/* DestroyActorSafe */
-
-stock DestroyActorSafe(&actorid)
-{
-	new success = DestroyActor(actorid);
-	Iter_SafeRemove(Actor, actorid, actorid);
-	return success;
-}
-
-/* Iter_DestroyActor */
-
-stock Iter_DestroyActor(actorid)
-{
-	Iter_Remove(Actor, actorid);
-	return DestroyActor(actorid);
-}
-#if defined _ALS_DestroyActor
-	#undef DestroyActor
-#else
-	#define _ALS_DestroyActor
-#endif
-#define DestroyActor Iter_DestroyActor
 
 /*----------------------------------------------------------------------------*\
 Function:


### PR DESCRIPTION
First of all, this fixes foreach init under omp server since using any poolsize functions (like GetPlayerPoolSize) ruined the initial loops because of different return value when no players connected to the server (-1 in omp instead of 0 in samp server). The fix just uses `MAX_PLAYERS` / `MAX_VEHICLES` / `MAX_ACTORS` instead. We know poolsize functions much better and faster than taking maximal possible player slot value, but giving that we anyway use it at the init, this change hardly would be a problem for anyone.

Secondly, the recent changes which added vehicle and actor iterators weren't considered a case when foreach can be used for NPC recording scripts (when you include a_npc instead of a_samp). This PR also fix this, disabling anything other than NPC iterator for NPC scripts.

Thirdly, this weird piece of code running under omp server gave `[Warning] Parameter count does not match specifier in 'Script_Call'. callback: Iter_OnGameModeInit - fmat:  - count: 3)` so it was removed:
https://github.com/karimcambridge/samp-foreach/blob/52c881319d2f3c47eb0350eb639dc121391106d6/foreach.inc#L714-L721
It's completely pointless now being inside OnGameModeInit. The check will be always true (since player iterator was just cleared and cannot have any values than 0), and it won't let fill it with connected players if there are any at the moment of gamemode (re)start.

And the last one, some minor tab and space fixes here and there, where it was noticed.